### PR TITLE
Allow base-4.13 and time-1.9

### DIFF
--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -50,10 +50,10 @@ library
   -- ghc-options: -fplugin=DumpCore -fplugin-opt DumpCore:core-html
 
   build-depends:
-      base     >=4.3     && <4.13
+      base     >=4.3     && <4.14
     , deepseq  >=1.3.0.0 && <1.5
     , random   >=1.0     && <1.2
-    , time     >=1.2.0.3 && <1.9
+    , time     >=1.2.0.3 && <1.10
 
 source-repository head
   type:     git


### PR DESCRIPTION
Allows the versions bundled with GHC 8.8.1-alpha1. Library, tests and benchmarks run fine.