### PR TITLE
Fix link to bug tracker

### DIFF
--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -29,7 +29,7 @@ description:
 license:            BSD3
 license-file:       LICENSE
 maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
-bug-reports:        https://github.com/phadej/splitmix#issues
+bug-reports:        https://github.com/phadej/splitmix/issues
 category:           System, Random
 build-type:         Simple
 tested-with:


### PR DESCRIPTION
https://github.com/phadej/splitmix#issues doesn't lead anywhere in particular; the GitHub issues live at https://github.com/phadej/splitmix/issues.