### PR TITLE
instance Prim SMGen

### DIFF
--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -57,7 +57,7 @@ flag optimised-mixer
   default:     False
 
 flag random
-  description: Providen RandomGen SMGen instance
+  description: Provide RandomGen SMGen instance
   manual:      True
   default:     True
 
@@ -75,9 +75,10 @@ library
   -- ghc-options: -fplugin=DumpCore -fplugin-opt DumpCore:core-html
 
   build-depends:
-      base     >=4.3     && <4.15
-    , deepseq  >=1.3.0.0 && <1.5
-    , time     >=1.2.0.3 && <1.10
+      base      >=4.3     && <4.15
+    , deepseq   >=1.3.0.0 && <1.5
+    , primitive >=0.7.0   && <0.8
+    , time      >=1.2.0.3 && <1.10
 
   if flag(random)
     build-depends: random >=1.0 && <1.2

--- a/src/System/Random/SplitMix.hs
+++ b/src/System/Random/SplitMix.hs
@@ -69,8 +69,13 @@ import qualified System.Random as R
 #endif
 
 #if !__GHCJS__
-import Data.Primitive.Types (Prim, alignment#, defaultSetByteArray#, defaultSetOffAddr#, indexByteArray#, indexOffAddr#, readByteArray#, readOffAddr#, setByteArray#, setOffAddr#, sizeOf#, writeByteArray#, writeOffAddr#)
-import GHC.Exts             (Int (..), Addr#, ByteArray#, Int#, MutableByteArray#, State#, (*#), (+#))
+import Data.Primitive.Types
+       (Prim, alignment#, defaultSetByteArray#, defaultSetOffAddr#,
+       indexByteArray#, indexOffAddr#, readByteArray#, readOffAddr#,
+       setByteArray#, setOffAddr#, sizeOf#, writeByteArray#, writeOffAddr#)
+import GHC.Exts
+       (Addr#, ByteArray#, Int (..), Int#, MutableByteArray#, State#, (*#),
+       (+#))
 import System.CPUTime       (cpuTimePrecision, getCPUTime)
 #endif
 


### PR DESCRIPTION
Extracted from https://github.com/lehins/splitmix/commits/new-random.

This is mostly to get an idea for how open you would be to to this idea, @phadej.

For context: the new version of `random` we're working on over at https://github.com/idontgetoutmuch/random has a fast monadic PRNG implementation for all `RandomGen` instances that also implement `Prim`.

In addition, the new version of `random` will use this library's implementation of SplitMix as its default PRNG.

It would be nice for the default PRNG to be fast, so having a `Prim` instance for `SMGen` would be really good. Defining that instance requires looking into the data type itself, and the `SMGen` constructor is not exported, so the instance declaration must live in `splitmix` itself. That's what this PR adds.

Alternative: https://github.com/idontgetoutmuch/random/pull/76