### PR TITLE
Add INLINEABLE pragmas to bitmaskWithRejection*

### DIFF
--- a/src/System/Random/SplitMix.hs
+++ b/src/System/Random/SplitMix.hs
@@ -296,6 +296,7 @@ shiftXorMultiply n k w = shiftXor n w `mult` k
 bitmaskWithRejection32 :: Word32 -> SMGen -> (Word32, SMGen)
 bitmaskWithRejection32 0 = error "bitmaskWithRejection32 0"
 bitmaskWithRejection32 n = bitmaskWithRejection32' (n - 1)
+{-# INLINEABLE bitmaskWithRejection32 #-}
 
 -- | /Bitmask with rejection/ method of generating subrange of 'Word64'.
 --
@@ -309,6 +310,7 @@ bitmaskWithRejection32 n = bitmaskWithRejection32' (n - 1)
 bitmaskWithRejection64 :: Word64 -> SMGen -> (Word64, SMGen)
 bitmaskWithRejection64 0 = error "bitmaskWithRejection64 0"
 bitmaskWithRejection64 n = bitmaskWithRejection64' (n - 1)
+{-# INLINEABLE bitmaskWithRejection64 #-}
 
 -- | /Bitmask with rejection/ method of generating subrange of 'Word32'.
 --
@@ -324,6 +326,7 @@ bitmaskWithRejection32' range = go where
            in if x' > range
               then go g'
               else (x', g')
+{-# INLINEABLE bitmaskWithRejection32' #-}
 
 -- | /Bitmask with rejection/ method of generating subrange of 'Word64'.
 --
@@ -342,6 +345,7 @@ bitmaskWithRejection64' range = go where
            in if x' > range
               then go g'
               else (x', g')
+{-# INLINEABLE bitmaskWithRejection64' #-}
 
 
 -------------------------------------------------------------------------------

--- a/src/System/Random/SplitMix32.hs
+++ b/src/System/Random/SplitMix32.hs
@@ -278,6 +278,7 @@ mixGamma z0 =
 bitmaskWithRejection32 :: Word32 -> SMGen -> (Word32, SMGen)
 bitmaskWithRejection32 0 = error "bitmaskWithRejection32 0"
 bitmaskWithRejection32 n = bitmaskWithRejection32' (n - 1)
+{-# INLINEABLE bitmaskWithRejection32 #-}
 
 -- | /Bitmask with rejection/ method of generating subrange of 'Word64'.
 --
@@ -290,6 +291,7 @@ bitmaskWithRejection32 n = bitmaskWithRejection32' (n - 1)
 bitmaskWithRejection64 :: Word64 -> SMGen -> (Word64, SMGen)
 bitmaskWithRejection64 0 = error "bitmaskWithRejection64 0"
 bitmaskWithRejection64 n = bitmaskWithRejection64' (n - 1)
+{-# INLINEABLE bitmaskWithRejection64 #-}
 
 -- | /Bitmask with rejection/ method of generating subrange of 'Word32'.
 --
@@ -305,6 +307,7 @@ bitmaskWithRejection32' range = go where
            in if x' > range
               then go g'
               else (x', g')
+{-# INLINEABLE bitmaskWithRejection32' #-}
 
 -- | /Bitmask with rejection/ method of generating subrange of 'Word64'.
 --
@@ -323,6 +326,7 @@ bitmaskWithRejection64' range = go where
            in if x' > range
               then go g'
               else (x', g')
+{-# INLINEABLE bitmaskWithRejection64' #-}
 
 -------------------------------------------------------------------------------
 -- Initialisation


### PR DESCRIPTION
### Summary

It seems the local `mask` function in those two functions is sometimes not getting inlined. (Note changing those `INLINEABLE` pragmas to `{-# INLINEABLE mask #-}` also works, I'm not particularly familiar enough with the `INLINEABLE` pragma to really tell what's best practice here.)

TBH I don't have a full picture of what's happening, but I have some failing inspection tests to show. So, this patch works for me, but if you have any idea for a local test case to add before merging this I'd be happy to implement it.

### How to reproduce the issue

The tests are available in this branch of generic-random: https://github.com/Lysxia/generic-random/pull/23

Try testing `cabal new-test generic-random:inspect --flags=enable-inspect`. When built with the currently released version of splitmix, the test cases fail, and you can see in the reported Core that the RHS have an extra `mask` definition. With this patch both cases succeed (as they did originally, before QuickChick moved to splitmix).